### PR TITLE
fix: multiple editor issues

### DIFF
--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -75,7 +75,12 @@ class EditorState extends State<Editor> {
     }
 
     setState(() {
-      _currNumLines = lines.split('\n').length;
+      int subtractBefore = beforeController.text == '' ? 1 : 0;
+      int subtractAfter = afterController.text == '' ? 1 : 0;
+
+      int subtractLines = subtractBefore + subtractAfter;
+
+      _currNumLines = lines.split('\n').length - subtractLines;
     });
   }
 
@@ -166,7 +171,12 @@ class EditorState extends State<Editor> {
     }
 
     setState(() {
-      _currNumLines = file.content.split('\n').length;
+      int subtractBefore = beforeController.text == '' ? 1 : 0;
+      int subtractAfter = afterController.text == '' ? 1 : 0;
+
+      int subtractLines = subtractBefore + subtractAfter;
+
+      _currNumLines = file.content.split('\n').length - subtractLines;
     });
   }
 
@@ -291,7 +301,7 @@ class EditorState extends State<Editor> {
             scrollDirection: Axis.vertical,
             shrinkWrap: true,
             children: [
-              if (file.hasRegion)
+              if (file.hasRegion && beforeController.text.isNotEmpty)
                 TextField(
                   smartQuotesType: SmartQuotesType.disabled,
                   smartDashesType: SmartDashesType.disabled,
@@ -339,7 +349,7 @@ class EditorState extends State<Editor> {
                   color: Colors.white.withOpacity(0.87),
                 ),
               ),
-              if (file.hasRegion)
+              if (file.hasRegion && afterController.text.isNotEmpty)
                 TextField(
                   smartQuotesType: SmartQuotesType.disabled,
                   smartDashesType: SmartDashesType.disabled,

--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -160,8 +160,8 @@ class EditorState extends State<Editor> {
         afterController.text = afterEditableRegionText;
       }
     } else {
-      beforeController.text = '';
-      inController.text = file.content;
+      beforeController.text = file.content;
+      inController.text = '';
       afterController.text = '';
     }
 
@@ -282,102 +282,83 @@ class EditorState extends State<Editor> {
           height: 1000,
           width: 2500,
           child: ListView(
-            padding: const EdgeInsets.only(top: 10),
+            padding: widget.options.hasRegion
+                ? const EdgeInsets.only(top: 10)
+                : const EdgeInsets.only(top: 0),
             controller: scrollController,
             scrollDirection: Axis.vertical,
             shrinkWrap: true,
             children: [
               if (file.hasRegion)
-                SizedBox(
-                  width: 2500,
-                  child: TextField(
-                    smartQuotesType: SmartQuotesType.disabled,
-                    smartDashesType: SmartDashesType.disabled,
-                    controller: beforeController,
-                    decoration: InputDecoration(
-                      border: InputBorder.none,
-                      fillColor: widget.options.editorBackgroundColor,
-                      filled: true,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.only(
-                        left: 10,
-                      ),
-                    ),
-                    maxLines: null,
-                    style: TextStyle(
-                      fontSize: 18,
-                      color: Colors.white.withOpacity(0.87),
-                    ),
-                    onChanged: (String event) {
-                      handleTextChange(file, event, 'BEFORE');
-                    },
-                  ),
-                ),
-              Container(
-                width: 2500,
-                decoration: file.hasRegion
-                    ? BoxDecoration(
-                        border: Border(
-                          left: BorderSide(
-                            width: 5,
-                            color: file.region.condition
-                                ? Colors.green
-                                : Colors.grey,
-                          ),
-                        ),
-                      )
-                    : null,
-                child: TextField(
+                TextField(
                   smartQuotesType: SmartQuotesType.disabled,
                   smartDashesType: SmartDashesType.disabled,
-                  controller: inController,
+                  controller: beforeController,
                   decoration: InputDecoration(
                     border: InputBorder.none,
-                    fillColor: file.hasRegion
-                        ? file.region.color
-                        : widget.options.editorBackgroundColor,
+                    fillColor: widget.options.editorBackgroundColor,
                     filled: true,
                     isDense: true,
-                    contentPadding: EdgeInsets.only(
+                    contentPadding: const EdgeInsets.only(
                       left: 10,
-                      top: file.hasRegion ? 0 : 10,
                     ),
                   ),
-                  onChanged: (String event) {
-                    handleTextChange(file, event, 'IN');
-                  },
                   maxLines: null,
                   style: TextStyle(
                     fontSize: 18,
                     color: Colors.white.withOpacity(0.87),
                   ),
+                  onChanged: (String event) {
+                    handleTextChange(file, event, 'BEFORE');
+                  },
+                ),
+              TextField(
+                smartQuotesType: SmartQuotesType.disabled,
+                smartDashesType: SmartDashesType.disabled,
+                controller: inController,
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  fillColor: file.hasRegion
+                      ? file.region.color
+                      : widget.options.editorBackgroundColor,
+                  filled: true,
+                  isDense: true,
+                  contentPadding: EdgeInsets.only(
+                    left: 10,
+                    top: file.hasRegion ? 0 : 10,
+                  ),
+                ),
+                onChanged: (String event) {
+                  handleTextChange(file, event, 'IN');
+                },
+                maxLines: null,
+                style: TextStyle(
+                  fontSize: 18,
+                  color: Colors.white.withOpacity(0.87),
                 ),
               ),
               if (file.hasRegion)
-                SizedBox(
-                  width: 2500,
-                  child: TextField(
-                    smartQuotesType: SmartQuotesType.disabled,
-                    smartDashesType: SmartDashesType.disabled,
-                    controller: afterController,
-                    decoration: InputDecoration(
-                      border: InputBorder.none,
-                      filled: true,
-                      fillColor: widget.options.editorBackgroundColor,
-                      contentPadding: const EdgeInsets.only(
-                        left: 10,
-                      ),
-                      isDense: true,
+                TextField(
+                  smartQuotesType: SmartQuotesType.disabled,
+                  smartDashesType: SmartDashesType.disabled,
+                  controller: afterController,
+                  decoration: InputDecoration(
+                    border: InputBorder.none,
+                    filled: true,
+                    fillColor: widget.options.editorBackgroundColor,
+                    contentPadding: const EdgeInsets.only(
+                      left: 10,
                     ),
-                    maxLines: null,
-                    style: TextStyle(
-                      fontSize: 18,
-                      color: Colors.white.withOpacity(0.87),
-                    ),
-                    onChanged: (String event) {
-                      handleTextChange(file, event, 'AFTER');
-                    },
+                    isDense: true,
                   ),
+                  maxLines: null,
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Colors.white.withOpacity(0.87),
+                  ),
+                  onChanged: (String event) {
+                    handleTextChange(file, event, 'AFTER');
+                  },
                 ),
             ],
           ),

--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -160,8 +160,8 @@ class EditorState extends State<Editor> {
         afterController.text = afterEditableRegionText;
       }
     } else {
-      beforeController.text = file.content;
-      inController.text = '';
+      beforeController.text = '';
+      inController.text = file.content;
       afterController.text = '';
     }
 

--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -53,19 +53,25 @@ class EditorState extends State<Editor> {
     if (widget.options.hasRegion) {
       switch (region) {
         case 'BEFORE':
-          lines =
-              event + '\n' + inController.text + '\n' + afterController.text;
+          lines = event +
+              (event.isNotEmpty ? '\n' : '') +
+              inController.text +
+              (afterController.text.isNotEmpty ? '\n' : '') +
+              afterController.text;
           break;
         case 'IN':
           lines = beforeController.text +
-              '\n' +
+              (beforeController.text.isNotEmpty ? '\n' : '') +
               event +
-              '\n' +
+              (afterController.text.isNotEmpty ? '\n' : '') +
               afterController.text;
           break;
         case 'AFTER':
-          lines =
-              beforeController.text + '\n' + inController.text + '\n' + event;
+          lines = beforeController.text +
+              (beforeController.text.isNotEmpty ? '\n' : '') +
+              inController.text +
+              (event.isNotEmpty ? '\n' : '') +
+              event;
           break;
       }
     }
@@ -75,12 +81,7 @@ class EditorState extends State<Editor> {
     }
 
     setState(() {
-      int subtractBefore = beforeController.text == '' ? 1 : 0;
-      int subtractAfter = afterController.text == '' ? 1 : 0;
-
-      int subtractLines = subtractBefore + subtractAfter;
-
-      _currNumLines = lines.split('\n').length - subtractLines;
+      _currNumLines = lines.split('\n').length;
     });
   }
 
@@ -173,12 +174,7 @@ class EditorState extends State<Editor> {
     }
 
     setState(() {
-      int subtractBefore = beforeController.text == '' ? 1 : 0;
-      int subtractAfter = afterController.text == '' ? 1 : 0;
-
-      int subtractLines = subtractBefore + subtractAfter;
-
-      _currNumLines = file.content.split('\n').length - subtractLines;
+      _currNumLines = file.content.split('\n').length;
     });
   }
 

--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -116,16 +116,18 @@ class EditorState extends State<Editor> {
               int.parse(prefs.getString(file.id)?.split(':')[0] ?? '');
         }
 
-        Future.delayed(const Duration(seconds: 0), () {
-          double offset =
-              fileContent.split('\n').sublist(0, regionStart - 1).length *
-                  getTextHeight(context);
-          scrollController.animateTo(
-            offset,
-            duration: const Duration(milliseconds: 500),
-            curve: Curves.easeInOut,
-          );
-        });
+        if (file.content.split('\n').length > 7) {
+          Future.delayed(const Duration(seconds: 0), () {
+            double offset =
+                fileContent.split('\n').sublist(0, regionStart - 1).length *
+                    getTextHeight(context);
+            scrollController.animateTo(
+              offset,
+              duration: const Duration(milliseconds: 500),
+              curve: Curves.easeInOut,
+            );
+          });
+        }
       }
       scrollController.addListener(() {
         linebarController.jumpTo(scrollController.offset);

--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -275,6 +275,7 @@ class EditorState extends State<Editor> {
   Widget editorView(BuildContext context, FileIDE file) {
     return ListView(
       padding: const EdgeInsets.only(top: 0),
+      physics: const ClampingScrollPhysics(),
       scrollDirection: Axis.horizontal,
       controller: horizontalController,
       children: [
@@ -285,6 +286,7 @@ class EditorState extends State<Editor> {
             padding: widget.options.hasRegion
                 ? const EdgeInsets.only(top: 10)
                 : const EdgeInsets.only(top: 0),
+            physics: const ClampingScrollPhysics(),
             controller: scrollController,
             scrollDirection: Axis.vertical,
             shrinkWrap: true,


### PR DESCRIPTION
- fixes: top-padding when no region field is present in any way.
- fixes: scrolling beyond the list boundary for vertical and horizontal listview
- feat: before and after fields will no longer be present when there is no text present. (When a region field is present)
- fixes: out of index bug, which was caused by the scroll controller function which tried to split on an index which did not exist if the line count was one or less.
