### PR TITLE
feat: migrate editor syntax highlighting to TextMate (HTML/CSS/JS)

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -116,26 +116,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -164,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -329,18 +329,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -366,5 +366,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/lib/controller/custom_text_controller.dart
+++ b/lib/controller/custom_text_controller.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_highlight/themes/atom-one-dark-reasonable.dart';
-import 'package:highlight/highlight.dart' show highlight, Node;
+import 'package:phone_ide/highlighting/textmate_highlighter_registry.dart';
 
 class TextEditingControllerIDE extends TextEditingController {
   TextEditingControllerIDE({Key? key, this.font, this.language = 'HTML'});
@@ -8,55 +7,16 @@ class TextEditingControllerIDE extends TextEditingController {
   String language;
   final TextStyle? font;
 
-  List<TextSpan> _convert(List<Node> nodes) {
-    List<TextSpan> spans = [];
-    var currentSpans = spans;
-    List<List<TextSpan>> stack = [];
-
-    traverse(Node node) {
-      if (node.value != null) {
-        currentSpans.add(
-          node.className == null
-              ? TextSpan(text: node.value)
-              : TextSpan(
-                  text: node.value,
-                  style: atomOneDarkReasonableTheme[node.className!],
-                ),
-        );
-      } else if (node.children != null) {
-        List<TextSpan> tmp = [];
-        currentSpans.add(
-          TextSpan(
-            children: tmp,
-            style: atomOneDarkReasonableTheme[node.className!],
-          ),
-        );
-        stack.add(currentSpans);
-        currentSpans = tmp;
-
-        for (var n in node.children!) {
-          traverse(n);
-          if (n == node.children!.last) {
-            currentSpans = stack.isEmpty ? spans : stack.removeLast();
-          }
-        }
-      }
-    }
-
-    for (var node in nodes) {
-      traverse(node);
-    }
-
-    return spans;
-  }
-
   @override
   TextSpan buildTextSpan({
     required BuildContext context,
     TextStyle? style,
     required bool withComposing,
   }) {
-    var nodes = highlight.parse(text, language: language).nodes!;
-    return TextSpan(style: style, children: _convert(nodes));
+    return TextMateHighlighterRegistry.instance.buildTextSpan(
+      text: text,
+      language: language,
+      style: style,
+    );
   }
 }

--- a/lib/editor/editor.dart
+++ b/lib/editor/editor.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:phone_ide/controller/custom_text_controller.dart';
 import 'package:phone_ide/editor/editor_options.dart';
 import 'package:phone_ide/editor/linebar.dart';
+import 'package:phone_ide/highlighting/textmate_highlighter_registry.dart';
 import 'package:phone_ide/models/textfield_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -64,7 +65,7 @@ class EditorState extends State<Editor> {
   @override
   void initState() {
     super.initState();
-    handleFileInit();
+    _initializeEditor();
 
     _textfieldDataSub = widget.textfieldData.stream.listen((event) {
       handleTextChange(
@@ -88,7 +89,35 @@ class EditorState extends State<Editor> {
     _textfieldDataSub.cancel();
   }
 
-  bool isLoading = false;
+  bool isLoading = true;
+
+  Future<void> _initializeEditor() async {
+    await TextMateHighlighterRegistry.instance.initialize();
+    if (!mounted) return;
+    try {
+      await handleFileInit();
+    } catch (error) {
+      if (!mounted) return;
+      debugPrint(
+        'phone_ide: Editor initialization fallback due to error: $error',
+      );
+      setState(() {
+        isLoading = false;
+      });
+    }
+  }
+
+  Future<SharedPreferences?> _getPreferencesSafe() async {
+    try {
+      return await SharedPreferences.getInstance();
+    } catch (error) {
+      debugPrint(
+        'phone_ide: SharedPreferences unavailable, continuing without cache: '
+        '$error',
+      );
+      return null;
+    }
+  }
 
   void updateLineCount(String event, RegionPosition region) async {
     if (!mounted) return;
@@ -153,19 +182,19 @@ class EditorState extends State<Editor> {
     return calculatedFontSize;
   }
 
-  handleFileInit() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
+  Future<void> handleFileInit() async {
+    final prefs = await _getPreferencesSafe();
     String fileContent = widget.defaultValue;
     EditorRegionOptions? region = widget.options.regionOptions;
 
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      handleRegionFields();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+      await handleRegionFields();
 
       if (region != null) {
         int regionStart = region.start!;
-        if (prefs.get(widget.path) != null) {
+        if (prefs?.get(widget.path) != null) {
           regionStart = int.parse(
-            prefs.getString(widget.path)?.split(':')[0] ?? '',
+            prefs?.getString(widget.path)?.split(':')[0] ?? '',
           );
         }
 
@@ -190,7 +219,10 @@ class EditorState extends State<Editor> {
         linebarController.jumpTo(0);
         scrollController.jumpTo(0);
       }
-      isLoading = false;
+      if (!mounted) return;
+      setState(() {
+        isLoading = false;
+      });
     });
 
     beforeController.language = widget.defaultLanguage;
@@ -199,7 +231,7 @@ class EditorState extends State<Editor> {
   }
 
   handleRegionFields() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
+    final prefs = await _getPreferencesSafe();
     EditorRegionOptions? region = widget.options.regionOptions;
     String path = widget.path;
     String fileContent = widget.defaultValue;
@@ -208,9 +240,9 @@ class EditorState extends State<Editor> {
       int regionStart = region.start!;
       int regionEnd = region.end!;
 
-      if (prefs.get(path) != null) {
-        regionStart = int.parse(prefs.getString(path)?.split(':')[0] ?? '');
-        regionEnd = int.parse(prefs.getString(path)?.split(':')[1] ?? '');
+      if (prefs?.get(path) != null) {
+        regionStart = int.parse(prefs?.getString(path)?.split(':')[0] ?? '');
+        regionEnd = int.parse(prefs?.getString(path)?.split(':')[1] ?? '');
       }
 
       int lines = fileContent.split('\n').length;
@@ -242,7 +274,8 @@ class EditorState extends State<Editor> {
   }
 
   handleRegionCaching(String event, RegionPosition region) async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
+    final prefs = await _getPreferencesSafe();
+    if (prefs == null) return;
     late int beforeRegionLines;
     late int inRegionLines;
     late int newRegionlines;

--- a/lib/highlighting/textmate_highlighter_registry.dart
+++ b/lib/highlighting/textmate_highlighter_registry.dart
@@ -1,0 +1,713 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:syntax_highlight/syntax_highlight.dart';
+
+typedef HighlighterLogger = void Function(String message);
+
+class SanitizedGrammarResult {
+  const SanitizedGrammarResult({
+    required this.sanitizedJson,
+    required this.replacedPatternCount,
+    required this.invalidPatternSamples,
+  });
+
+  final String sanitizedJson;
+  final int replacedPatternCount;
+  final List<String> invalidPatternSamples;
+}
+
+class TextMateHighlighterRegistry {
+  TextMateHighlighterRegistry._({
+    AssetBundle? assetBundle,
+    HighlighterLogger? logger,
+  })  : _assetBundle = assetBundle ?? rootBundle,
+        _logger = logger ?? debugPrint;
+
+  static final TextMateHighlighterRegistry instance =
+      TextMateHighlighterRegistry._();
+
+  @visibleForTesting
+  static TextMateHighlighterRegistry createForTests({
+    AssetBundle? assetBundle,
+    HighlighterLogger? logger,
+  }) {
+    return TextMateHighlighterRegistry._(
+      assetBundle: assetBundle,
+      logger: logger,
+    );
+  }
+
+  static const Set<String> supportedLanguages = {
+    'html',
+    'css',
+    'javascript',
+  };
+
+  static const Map<String, String> _languageAliases = {
+    'html': 'html',
+    'htm': 'html',
+    'css': 'css',
+    'javascript': 'javascript',
+    'js': 'javascript',
+  };
+
+  static const Set<String> _regexKeys = {
+    'match',
+    'begin',
+    'end',
+    'while',
+  };
+
+  static const String _neverMatchingRegexPattern = r'^(?!x)x';
+  static const String _scriptEmbedBeginPattern = r'(<script)(\s[^>]*?)?>';
+  static const String _styleEmbedBeginPattern = r'(<style)(\s[^>]*?)?>';
+  static const String _cssRuleSetBeginPattern =
+      r'''([a-zA-Z0-9\-_*#.,:>+~\[\]\s"'()=|^$]+)\s*(\{)''';
+  static final RegExp _embeddedBlockRegex = RegExp(
+    r'(<script\b[^>]*>)([\s\S]*?)(</script\s*>)|(<style\b[^>]*>)([\s\S]*?)(</style\s*>)',
+    caseSensitive: false,
+    multiLine: true,
+  );
+
+  static String? canonicalizeLanguage(String language) {
+    final normalized = language.trim().toLowerCase();
+    if (normalized.isEmpty) return null;
+    return _languageAliases[normalized];
+  }
+
+  bool _isInitialized = false;
+  bool _initializationFailed = false;
+  Future<void>? _initializeFuture;
+
+  AssetBundle _assetBundle;
+  HighlighterLogger _logger;
+  HighlighterTheme? _theme;
+
+  final Map<String, Highlighter> _highlighters = {};
+  final Set<String> _loggedUnsupportedLanguages = {};
+  final Set<String> _loggedFallbackKeys = {};
+
+  bool get isInitialized => _isInitialized;
+  bool get initializationFailed => _initializationFailed;
+
+  Future<void> initialize() {
+    return _initializeFuture ??= _initializeInternal();
+  }
+
+  Future<void> _initializeInternal() async {
+    if (_isInitialized) return;
+    _initializationFailed = false;
+
+    try {
+      final theme = _createTheme();
+      _theme = theme;
+
+      final rawGrammars = <String, String>{};
+      for (final language in supportedLanguages) {
+        rawGrammars[language] = await _assetBundle.loadString(
+          'packages/syntax_highlight/grammars/$language.json',
+        );
+      }
+
+      final patchedCssGrammar =
+          patchCssGrammarForSelectors(rawGrammars['css']!);
+      final preparedGrammars = <String, String>{
+        ...rawGrammars,
+        'css': patchedCssGrammar,
+        'html': patchHtmlGrammarForEmbeddedLanguages(
+          htmlGrammarJson: rawGrammars['html']!,
+          cssGrammarJson: patchedCssGrammar,
+          jsGrammarJson: rawGrammars['javascript']!,
+        ),
+        'javascript': patchJavaScriptGrammarForFunctionCalls(
+          rawGrammars['javascript']!,
+        ),
+      };
+
+      for (final language in supportedLanguages) {
+        final grammarJson = preparedGrammars[language]!;
+        final sanitized = sanitizeGrammar(grammarJson);
+        if (sanitized.replacedPatternCount > 0) {
+          _logger(
+            'phone_ide: TextMate grammar "$language" replaced '
+            '${sanitized.replacedPatternCount} unsupported regex patterns. '
+            'Samples: ${sanitized.invalidPatternSamples.join(', ')}',
+          );
+        }
+
+        Highlighter.addLanguage(language, sanitized.sanitizedJson);
+        _highlighters[language] = Highlighter(language: language, theme: theme);
+      }
+
+      _isInitialized = true;
+    } catch (error) {
+      _initializationFailed = true;
+      _logger(
+        'phone_ide: TextMate initialization failed, falling back to plain text. '
+        'Error: $error',
+      );
+    }
+  }
+
+  TextSpan buildTextSpan({
+    required String text,
+    required String language,
+    TextStyle? style,
+  }) {
+    final canonicalLanguage = canonicalizeLanguage(language);
+
+    if (canonicalLanguage == null) {
+      _logUnsupportedLanguage(language);
+      return TextSpan(style: style, text: text);
+    }
+
+    if (!_isInitialized || _initializationFailed) {
+      _logFallback(
+        'not-initialized:$canonicalLanguage',
+        'phone_ide: TextMate not ready for "$canonicalLanguage", '
+            'using plain text fallback.',
+      );
+      return TextSpan(style: style, text: text);
+    }
+
+    final highlighter = _highlighters[canonicalLanguage];
+    if (highlighter == null || _theme == null) {
+      _logFallback(
+        'missing-highlighter:$canonicalLanguage',
+        'phone_ide: Missing highlighter for "$canonicalLanguage", '
+            'using plain text fallback.',
+      );
+      return TextSpan(style: style, text: text);
+    }
+
+    try {
+      if (canonicalLanguage == 'html') {
+        return _highlightHtmlWithEmbeddedBlocks(
+          text: text,
+          style: style,
+          htmlHighlighter: highlighter,
+        );
+      }
+
+      final highlighted = highlighter.highlight(text);
+      return TextSpan(style: style, children: [highlighted]);
+    } catch (error) {
+      _logFallback(
+        'highlight-error:$canonicalLanguage',
+        'phone_ide: Highlight error for "$canonicalLanguage", '
+            'using plain text fallback. Error: $error',
+      );
+      return TextSpan(style: style, text: text);
+    }
+  }
+
+  TextSpan _highlightHtmlWithEmbeddedBlocks({
+    required String text,
+    required TextStyle? style,
+    required Highlighter htmlHighlighter,
+  }) {
+    final jsHighlighter = _highlighters['javascript'];
+    final cssHighlighter = _highlighters['css'];
+
+    if (jsHighlighter == null || cssHighlighter == null) {
+      final highlighted = htmlHighlighter.highlight(text);
+      return TextSpan(style: style, children: [highlighted]);
+    }
+
+    final children = <InlineSpan>[];
+    var cursor = 0;
+
+    for (final match in _embeddedBlockRegex.allMatches(text)) {
+      if (match.start > cursor) {
+        final htmlSegment = text.substring(cursor, match.start);
+        children.add(htmlHighlighter.highlight(htmlSegment));
+      }
+
+      if (match.group(1) != null) {
+        final openTag = match.group(1)!;
+        final scriptBody = match.group(2)!;
+        final closeTag = match.group(3)!;
+
+        children.add(htmlHighlighter.highlight(openTag));
+        children.add(jsHighlighter.highlight(scriptBody));
+        children.add(htmlHighlighter.highlight(closeTag));
+      } else {
+        final openTag = match.group(4)!;
+        final styleBody = match.group(5)!;
+        final closeTag = match.group(6)!;
+
+        children.add(htmlHighlighter.highlight(openTag));
+        children.add(cssHighlighter.highlight(styleBody));
+        children.add(htmlHighlighter.highlight(closeTag));
+      }
+
+      cursor = match.end;
+    }
+
+    if (cursor < text.length) {
+      children.add(htmlHighlighter.highlight(text.substring(cursor)));
+    }
+
+    return TextSpan(style: style, children: children);
+  }
+
+  void _logUnsupportedLanguage(String language) {
+    final key = language.trim().toLowerCase();
+    if (!_loggedUnsupportedLanguages.add(key)) return;
+    _logger(
+      'phone_ide: Unsupported language "$language". '
+      'Supported languages: ${supportedLanguages.join(', ')}.',
+    );
+  }
+
+  void _logFallback(String key, String message) {
+    if (_loggedFallbackKeys.add(key)) {
+      _logger(message);
+    }
+  }
+
+  HighlighterTheme _createTheme() {
+    final themeConfig = jsonEncode(_atomOneDarkThemeConfig);
+    return HighlighterTheme.fromConfiguration(
+      themeConfig,
+      const TextStyle(),
+    );
+  }
+
+  @visibleForTesting
+  void configureForTests({
+    AssetBundle? assetBundle,
+    HighlighterLogger? logger,
+  }) {
+    _assetBundle = assetBundle ?? rootBundle;
+    _logger = logger ?? debugPrint;
+    _isInitialized = false;
+    _initializationFailed = false;
+    _initializeFuture = null;
+    _theme = null;
+    _highlighters.clear();
+    _loggedUnsupportedLanguages.clear();
+    _loggedFallbackKeys.clear();
+  }
+
+  @visibleForTesting
+  static SanitizedGrammarResult sanitizeGrammar(String grammarJson) {
+    final decoded = jsonDecode(grammarJson);
+    final sanitization = _RegexSanitization();
+    final sanitized = _sanitizeValue(decoded, sanitization);
+
+    return SanitizedGrammarResult(
+      sanitizedJson: jsonEncode(sanitized),
+      replacedPatternCount: sanitization.replacedPatternCount,
+      invalidPatternSamples: List.unmodifiable(sanitization.samples),
+    );
+  }
+
+  @visibleForTesting
+  static String patchHtmlGrammarForEmbeddedLanguages({
+    required String htmlGrammarJson,
+    required String cssGrammarJson,
+    required String jsGrammarJson,
+  }) {
+    final htmlGrammar =
+        (jsonDecode(htmlGrammarJson) as Map).cast<String, Object?>();
+    final cssGrammar =
+        (jsonDecode(cssGrammarJson) as Map).cast<String, Object?>();
+    final jsGrammar =
+        (jsonDecode(jsGrammarJson) as Map).cast<String, Object?>();
+
+    final cssPatterns = _expandTopLevelPatterns(cssGrammar);
+    final jsPatterns = _expandTopLevelPatterns(jsGrammar);
+
+    final patched = _patchHtmlValue(
+      htmlGrammar,
+      cssPatterns: cssPatterns,
+      jsPatterns: jsPatterns,
+    );
+
+    return jsonEncode(patched);
+  }
+
+  @visibleForTesting
+  static String patchJavaScriptGrammarForFunctionCalls(String grammarJson) {
+    final grammar = (jsonDecode(grammarJson) as Map).cast<String, Object?>();
+    final patterns = ((grammar['patterns'] as List?) ?? const <Object?>[])
+        .cast<Object?>()
+        .toList();
+
+    patterns.addAll(const <Object?>[
+      <String, Object?>{
+        'name': 'entity.name.function.js',
+        'match': r'\b([A-Za-z_$][A-Za-z0-9_$]*)\s*(?=\()',
+      },
+      <String, Object?>{
+        'match': r'(\.)\s*([A-Za-z_$][A-Za-z0-9_$]*)\b',
+        'captures': <String, Object?>{
+          '2': <String, Object?>{
+            'name': 'support.function.js',
+          },
+        },
+      },
+    ]);
+
+    final patched = <String, Object?>{
+      ...grammar,
+      'patterns': patterns,
+    };
+
+    return jsonEncode(patched);
+  }
+
+  @visibleForTesting
+  static String patchCssGrammarForSelectors(String grammarJson) {
+    final grammar = (jsonDecode(grammarJson) as Map).cast<String, Object?>();
+    final patched = _patchCssValue(grammar);
+    return jsonEncode(patched);
+  }
+
+  static List<Object?> _expandTopLevelPatterns(Map<String, Object?> grammar) {
+    final patterns =
+        ((grammar['patterns'] as List?) ?? const <Object?>[]).cast<Object?>();
+    final repository =
+        ((grammar['repository'] as Map?) ?? const <Object, Object>{})
+            .cast<String, Object?>();
+    return _expandPatternList(patterns, repository, <String>{});
+  }
+
+  static List<Object?> _expandPatternList(
+    List<Object?> patterns,
+    Map<String, Object?> repository,
+    Set<String> includeStack,
+  ) {
+    final expanded = <Object?>[];
+    for (final pattern in patterns) {
+      if (pattern is! Map) continue;
+      final map = pattern.cast<String, Object?>();
+      expanded.addAll(
+        _expandPatternMap(map, repository, includeStack),
+      );
+    }
+    return expanded;
+  }
+
+  static List<Object?> _expandPatternMap(
+    Map<String, Object?> pattern,
+    Map<String, Object?> repository,
+    Set<String> includeStack,
+  ) {
+    final includeValue = pattern['include'];
+    if (includeValue is String) {
+      if (!includeValue.startsWith('#')) {
+        return <Object?>[_deepCopyMap(pattern)];
+      }
+
+      final includeKey = includeValue.substring(1);
+      if (includeStack.contains(includeKey)) {
+        return const <Object?>[];
+      }
+
+      final includedPattern = repository[includeKey];
+      if (includedPattern is! Map) {
+        return const <Object?>[];
+      }
+
+      return _expandPatternMap(
+        includedPattern.cast<String, Object?>(),
+        repository,
+        {...includeStack, includeKey},
+      );
+    }
+
+    final copy = _deepCopyMap(pattern);
+    final nestedPatterns = copy['patterns'];
+    if (nestedPatterns is List) {
+      copy['patterns'] = _expandPatternList(
+        nestedPatterns.cast<Object?>(),
+        repository,
+        includeStack,
+      );
+    }
+
+    return <Object?>[copy];
+  }
+
+  static Object? _patchHtmlValue(
+    Object? value, {
+    required List<Object?> cssPatterns,
+    required List<Object?> jsPatterns,
+  }) {
+    if (value is Map) {
+      final map = <String, Object?>{};
+      for (final entry in value.entries) {
+        map[entry.key.toString()] = _patchHtmlValue(
+          entry.value,
+          cssPatterns: cssPatterns,
+          jsPatterns: jsPatterns,
+        );
+      }
+
+      final includeValue = map['include'];
+      if (includeValue == 'source.css') {
+        return <String, Object?>{
+          'patterns': _deepCopyList(cssPatterns),
+        };
+      }
+      if (includeValue == 'source.js') {
+        return <String, Object?>{
+          'patterns': _deepCopyList(jsPatterns),
+        };
+      }
+
+      final matcherName = map['name'];
+      if (matcherName == 'meta.embedded.script.html') {
+        map['begin'] = _scriptEmbedBeginPattern;
+      } else if (matcherName == 'meta.embedded.style.html') {
+        map['begin'] = _styleEmbedBeginPattern;
+      }
+
+      return map;
+    }
+
+    if (value is List) {
+      return value
+          .map((entry) => _patchHtmlValue(
+                entry,
+                cssPatterns: cssPatterns,
+                jsPatterns: jsPatterns,
+              ))
+          .toList();
+    }
+
+    return value;
+  }
+
+  static Object? _patchCssValue(Object? value) {
+    if (value is Map) {
+      final map = <String, Object?>{};
+      for (final entry in value.entries) {
+        map[entry.key.toString()] = _patchCssValue(entry.value);
+      }
+
+      if (map['name'] == 'meta.rule-set.css') {
+        map['begin'] = _cssRuleSetBeginPattern;
+      }
+      return map;
+    }
+
+    if (value is List) {
+      return value.map(_patchCssValue).toList();
+    }
+
+    return value;
+  }
+
+  static Map<String, Object?> _deepCopyMap(Map<String, Object?> source) {
+    final copy = <String, Object?>{};
+    for (final entry in source.entries) {
+      copy[entry.key] = _deepCopyValue(entry.value);
+    }
+    return copy;
+  }
+
+  static List<Object?> _deepCopyList(List<Object?> source) {
+    return source.map(_deepCopyValue).toList();
+  }
+
+  static Object? _deepCopyValue(Object? value) {
+    if (value is Map) {
+      return _deepCopyMap(value.cast<String, Object?>());
+    }
+    if (value is List) {
+      return _deepCopyList(value.cast<Object?>());
+    }
+    return value;
+  }
+
+  static Object? _sanitizeValue(
+      Object? value, _RegexSanitization sanitization) {
+    if (value is Map) {
+      final map = <String, Object?>{};
+      for (final entry in value.entries) {
+        final key = entry.key.toString();
+        final currentValue = entry.value;
+
+        if (_regexKeys.contains(key) && currentValue is String) {
+          if (_isValidRegex(currentValue)) {
+            map[key] = currentValue;
+          } else {
+            sanitization.replacedPatternCount += 1;
+            if (sanitization.samples.length < 3) {
+              sanitization.samples.add(currentValue);
+            }
+            map[key] = _neverMatchingRegexPattern;
+          }
+          continue;
+        }
+
+        map[key] = _sanitizeValue(currentValue, sanitization);
+      }
+      return map;
+    }
+
+    if (value is List) {
+      return value.map((entry) => _sanitizeValue(entry, sanitization)).toList();
+    }
+
+    return value;
+  }
+
+  static bool _isValidRegex(String pattern) {
+    try {
+      RegExp(pattern, multiLine: true);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+class _RegexSanitization {
+  int replacedPatternCount = 0;
+  final List<String> samples = [];
+}
+
+const Map<String, Object?> _atomOneDarkThemeConfig = {
+  'name': 'phone_ide_atom_one_dark',
+  'settings': [
+    {
+      'settings': {
+        'foreground': '#ABB2BF',
+      },
+    },
+    {
+      'scope': [
+        'comment',
+        'punctuation.definition.comment',
+      ],
+      'settings': {
+        'foreground': '#5C6370',
+      },
+    },
+    {
+      'scope': [
+        'keyword',
+        'keyword.control',
+        'keyword.declaration',
+        'storage',
+      ],
+      'settings': {
+        'foreground': '#C678DD',
+      },
+    },
+    {
+      'scope': [
+        'string',
+        'constant.character',
+      ],
+      'settings': {
+        'foreground': '#98C379',
+      },
+    },
+    {
+      'scope': [
+        'constant.numeric',
+        'constant.language',
+      ],
+      'settings': {
+        'foreground': '#D19A66',
+      },
+    },
+    {
+      'scope': [
+        'entity.name.type',
+        'support.class',
+      ],
+      'settings': {
+        'foreground': '#E5C07B',
+      },
+    },
+    {
+      'scope': [
+        'entity.name.function',
+        'support.function',
+      ],
+      'settings': {
+        'foreground': '#61AFEF',
+      },
+    },
+    {
+      'scope': [
+        'entity.name.tag',
+        'entity.name.tag.script',
+        'entity.name.tag.style',
+      ],
+      'settings': {
+        'foreground': '#E06C75',
+      },
+    },
+    {
+      'scope': [
+        'entity.other.attribute-name',
+        'support.type.property-name',
+        'meta.object-literal.key',
+      ],
+      'settings': {
+        'foreground': '#D19A66',
+      },
+    },
+    {
+      'scope': [
+        'string.quoted',
+        'string.template',
+        'support.constant.property-value',
+        'support.type.media-query',
+        'support.type.keyframes',
+      ],
+      'settings': {
+        'foreground': '#98C379',
+      },
+    },
+    {
+      'scope': [
+        'meta.selector',
+        'entity.name.selector',
+        'entity.name.selector.css',
+      ],
+      'settings': {
+        'foreground': '#E5C07B',
+      },
+    },
+    {
+      'scope': [
+        'constant.character.entity',
+        'keyword.operator',
+      ],
+      'settings': {
+        'foreground': '#56B6C2',
+      },
+    },
+    {
+      'scope': [
+        'punctuation.definition.tag',
+        'punctuation.definition.string',
+        'punctuation.terminator',
+        'meta.brace',
+      ],
+      'settings': {
+        'foreground': '#ABB2BF',
+      },
+    },
+    {
+      'scope': [
+        'variable.language',
+        'variable.parameter',
+        'variable',
+      ],
+      'settings': {
+        'foreground': '#E06C75',
+      },
+    },
+  ],
+};

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -65,19 +89,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_highlight:
-    dependency: "direct main"
-    description:
-      name: flutter_highlight
-      sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -96,11 +120,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  highlight:
-    dependency: "direct main"
+  irondash_engine_context:
+    dependency: transitive
     description:
-      name: highlight
-      sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
+      name: irondash_engine_context
+      sha256: "2bb0bc13dfda9f5aaef8dde06ecc5feb1379f5bb387d59716d799554f3f305d7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.5"
+  irondash_message_channel:
+    dependency: transitive
+    description:
+      name: irondash_message_channel
+      sha256: b4101669776509c76133b8917ab8cfc704d3ad92a8c450b92934dd8884a2f060
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
@@ -192,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pixel_snap:
+    dependency: transitive
+    description:
+      name: pixel_snap
+      sha256: "677410ea37b07cd37ecb6d5e6c0d8d7615a7cf3bd92ba406fd1ac57e937d1fb0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   platform:
     dependency: transitive
     description:
@@ -301,6 +341,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  super_clipboard:
+    dependency: transitive
+    description:
+      name: super_clipboard
+      sha256: e73f3bb7e66cc9260efa1dc507f979138e7e106c3521e2dda2d0311f6d728a16
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
+  super_native_extensions:
+    dependency: transitive
+    description:
+      name: super_native_extensions
+      sha256: b9611dcb68f1047d6f3ef11af25e4e68a21b1a705bbcc3eb8cb4e9f5c3148569
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
+  syntax_highlight:
+    dependency: "direct main"
+    description:
+      name: syntax_highlight
+      sha256: "4d3ba40658cadba6ba55d697f29f00b43538ebb6eb4a0ca0e895c568eaced138"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   term_glyph:
     dependency: transitive
     description:
@@ -317,6 +381,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -341,6 +421,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -350,5 +446,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.8.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: ^2.0.13
-  highlight: ^0.7.0
-  flutter_highlight: ^0.7.0
+  syntax_highlight: ^0.5.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/editor_highlighting_test.dart
+++ b/test/editor_highlighting_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phone_ide/editor/editor.dart';
+import 'package:phone_ide/editor/editor_options.dart';
+import 'package:phone_ide/highlighting/textmate_highlighter_registry.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Editor highlighting', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      TextMateHighlighterRegistry.instance.configureForTests();
+    });
+
+    testWidgets('highlights HTML/CSS/JS and remains editable', (tester) async {
+      final samples = <String, String>{
+        'html': '<div class="x">hello</div>',
+        'css': 'body { color: red; }',
+        'javascript': 'const value = 42;',
+      };
+
+      for (final entry in samples.entries) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Editor(
+                options: EditorOptions(showLinebar: false),
+                defaultLanguage: entry.key,
+                defaultValue: entry.value,
+                path: 'file.${entry.key}',
+              ),
+            ),
+          ),
+        );
+
+        await _pumpUntilLoaded(tester);
+
+        final state = tester.state<EditorState>(find.byType(Editor));
+        final context = tester.element(find.byType(Editor));
+        final span = state.inController.buildTextSpan(
+          context: context,
+          style: const TextStyle(),
+          withComposing: false,
+        );
+
+        expect(_containsColorStyle(span), isTrue);
+
+        final editorField = find.byWidgetPredicate(
+          (widget) => widget is TextField && !widget.readOnly,
+        );
+        final newText = '${entry.value}\n// edited';
+        await tester.enterText(editorField, newText);
+        await tester.pump();
+
+        expect(state.inController.text, newText);
+      }
+    });
+
+    testWidgets('falls back to plain text when initialization fails',
+        (tester) async {
+      final logs = <String>[];
+      TextMateHighlighterRegistry.instance.configureForTests(
+        assetBundle: _FailingAssetBundle(),
+        logger: logs.add,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Editor(
+              options: EditorOptions(showLinebar: false),
+              defaultLanguage: 'html',
+              defaultValue: '<p>hello</p>',
+              path: 'index.html',
+            ),
+          ),
+        ),
+      );
+
+      await _pumpUntilLoaded(tester);
+
+      final state = tester.state<EditorState>(find.byType(Editor));
+      final context = tester.element(find.byType(Editor));
+      final span = state.inController.buildTextSpan(
+        context: context,
+        style: const TextStyle(),
+        withComposing: false,
+      );
+
+      expect(span.toPlainText(), state.inController.text);
+      expect(
+        logs.any((line) => line.contains('initialization failed')),
+        isTrue,
+      );
+
+      final editorField = find.byWidgetPredicate(
+        (widget) => widget is TextField && !widget.readOnly,
+      );
+      await tester.enterText(editorField, '<p>fallback still editable</p>');
+      await tester.pump();
+
+      expect(state.inController.text, '<p>fallback still editable</p>');
+    });
+  });
+}
+
+bool _containsColorStyle(TextSpan span) {
+  if (span.style?.color != null) return true;
+  for (final child in span.children ?? const <InlineSpan>[]) {
+    if (child is TextSpan && _containsColorStyle(child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+class _FailingAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) {
+    return Future<ByteData>.error(
+      StateError('Simulated load failure for $key'),
+    );
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) {
+    return Future<String>.error(
+      StateError('Simulated load failure for $key'),
+    );
+  }
+}
+
+Future<void> _pumpUntilLoaded(WidgetTester tester) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+    if (find.byType(CircularProgressIndicator).evaluate().isEmpty) {
+      return;
+    }
+  }
+  fail('Editor did not finish loading in test.');
+}

--- a/test/textmate_highlighter_registry_test.dart
+++ b/test/textmate_highlighter_registry_test.dart
@@ -1,0 +1,349 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phone_ide/highlighting/textmate_highlighter_registry.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TextMateHighlighterRegistry', () {
+    test('canonicalizes supported language aliases', () {
+      expect(TextMateHighlighterRegistry.canonicalizeLanguage('HTML'), 'html');
+      expect(TextMateHighlighterRegistry.canonicalizeLanguage('htm'), 'html');
+      expect(TextMateHighlighterRegistry.canonicalizeLanguage('css'), 'css');
+      expect(
+          TextMateHighlighterRegistry.canonicalizeLanguage('JS'), 'javascript');
+      expect(
+        TextMateHighlighterRegistry.canonicalizeLanguage('javascript'),
+        'javascript',
+      );
+      expect(TextMateHighlighterRegistry.canonicalizeLanguage('dart'), isNull);
+      expect(TextMateHighlighterRegistry.canonicalizeLanguage('  '), isNull);
+    });
+
+    test('unsupported language falls back to plain text and logs once', () {
+      final logs = <String>[];
+      final registry = TextMateHighlighterRegistry.createForTests(
+        logger: logs.add,
+      );
+
+      final first = registry.buildTextSpan(
+        text: 'print("hello")',
+        language: 'python',
+        style: const TextStyle(),
+      );
+      final second = registry.buildTextSpan(
+        text: 'print("world")',
+        language: 'python',
+        style: const TextStyle(),
+      );
+
+      expect(first.toPlainText(), 'print("hello")');
+      expect(second.toPlainText(), 'print("world")');
+      expect(
+        logs.where((line) => line.contains('Unsupported language')).length,
+        1,
+      );
+    });
+
+    test('invalid regex is replaced by grammar sanitizer', () {
+      final sanitized = TextMateHighlighterRegistry.sanitizeGrammar(
+        _grammarWithPattern('([a-z'),
+      );
+      final decoded =
+          jsonDecode(sanitized.sanitizedJson) as Map<String, Object?>;
+      final patterns = decoded['patterns'] as List<Object?>;
+      final matcher = patterns.first as Map<String, Object?>;
+
+      expect(sanitized.replacedPatternCount, 1);
+      expect(matcher['match'], r'^(?!x)x');
+      expect(sanitized.invalidPatternSamples, contains('([a-z'));
+    });
+
+    test('patches html embedded css/js includes for this parser', () {
+      final patched =
+          TextMateHighlighterRegistry.patchHtmlGrammarForEmbeddedLanguages(
+        htmlGrammarJson: _htmlGrammarWithEmbeddedIncludes(),
+        cssGrammarJson: _cssGrammarWithLocalInclude(),
+        jsGrammarJson: _jsGrammarWithLocalInclude(),
+      );
+
+      expect(patched.contains('source.css'), isFalse);
+      expect(patched.contains('source.js'), isFalse);
+
+      final decoded = jsonDecode(patched) as Map<String, Object?>;
+      final scriptBegin = _findBeginPatternForMatcher(
+        decoded,
+        'meta.embedded.script.html',
+      );
+      final styleBegin = _findBeginPatternForMatcher(
+        decoded,
+        'meta.embedded.style.html',
+      );
+
+      expect(scriptBegin, r'(<script)(\s[^>]*?)?>');
+      expect(styleBegin, r'(<style)(\s[^>]*?)?>');
+    });
+
+    test('patches javascript grammar with function call patterns', () {
+      final patched =
+          TextMateHighlighterRegistry.patchJavaScriptGrammarForFunctionCalls(
+              _jsGrammarWithLocalInclude());
+      final decoded = jsonDecode(patched) as Map<String, Object?>;
+      final patterns = decoded['patterns'] as List<Object?>;
+
+      expect(
+        patterns.any((entry) {
+          if (entry is! Map) return false;
+          final map = entry.cast<String, Object?>();
+          return map['name'] == 'entity.name.function.js';
+        }),
+        isTrue,
+      );
+
+      expect(
+        patterns.any((entry) {
+          if (entry is! Map) return false;
+          final map = entry.cast<String, Object?>();
+          return map['captures'] is Map;
+        }),
+        isTrue,
+      );
+    });
+
+    test('patches css grammar selector regex to support commas', () {
+      final patched = TextMateHighlighterRegistry.patchCssGrammarForSelectors(
+        _cssGrammarWithLocalInclude(),
+      );
+      final decoded = jsonDecode(patched) as Map<String, Object?>;
+      final begin = _findBeginPatternForMatcher(decoded, 'meta.rule-set.css');
+
+      expect(
+        begin,
+        r'''([a-zA-Z0-9\-_*#.,:>+~\[\]\s"'()=|^$]+)\s*(\{)''',
+      );
+    });
+
+    test('highlights embedded js and css inside html', () async {
+      final registry = TextMateHighlighterRegistry.createForTests();
+
+      await registry.initialize();
+
+      final span = registry.buildTextSpan(
+        text: '''
+<script>
+if (true) {}
+// hello
+console.log('hello world');
+</script>
+<style>
+h1 { color: red; }
+</style>
+''',
+        language: 'html',
+        style: const TextStyle(color: Colors.white),
+      );
+
+      final leaves = _flattenTextSpans(span);
+
+      final ifSpan = leaves.firstWhere((leaf) => leaf.text.contains('if'));
+      final commentSpan =
+          leaves.firstWhere((leaf) => leaf.text.contains('// hello'));
+      final functionSpan =
+          leaves.firstWhere((leaf) => leaf.text.contains('log'));
+      final cssPropertySpan =
+          leaves.firstWhere((leaf) => leaf.text.contains('color'));
+
+      expect(ifSpan.style.color, const Color(0xFFC678DD));
+      expect(commentSpan.style.color, const Color(0xFF5C6370));
+      expect(functionSpan.style.color, const Color(0xFF61AFEF));
+      expect(cssPropertySpan.style.color, const Color(0xFFD19A66));
+    });
+
+    test('highlights css selectors with selector color', () async {
+      final registry = TextMateHighlighterRegistry.createForTests();
+      await registry.initialize();
+
+      final span = registry.buildTextSpan(
+        text: '''
+body {
+  color: red;
+}
+
+.menu, h1 {
+  text-align: center;
+}
+''',
+        language: 'css',
+        style: const TextStyle(color: Colors.white),
+      );
+
+      final leaves = _flattenTextSpans(span);
+      final bodySelector =
+          leaves.firstWhere((leaf) => leaf.text.contains('body'));
+      final menuSelector =
+          leaves.firstWhere((leaf) => leaf.text.contains('.menu'));
+
+      expect(bodySelector.style.color, const Color(0xFFE5C07B));
+      expect(menuSelector.style.color, const Color(0xFFE5C07B));
+    });
+  });
+}
+
+String _grammarWithPattern(String pattern) {
+  return jsonEncode({
+    'name': 'TestGrammar',
+    'scopeName': 'source.test',
+    'patterns': [
+      {
+        'name': 'keyword.control.test',
+        'match': pattern,
+      }
+    ],
+  });
+}
+
+String _htmlGrammarWithEmbeddedIncludes() {
+  return jsonEncode({
+    'name': 'HTML',
+    'scopeName': 'text.html.basic',
+    'patterns': [
+      {'include': '#embeddedCode'}
+    ],
+    'repository': {
+      'embeddedCode': {
+        'patterns': [
+          {
+            'name': 'meta.embedded.script.html',
+            'begin': r'(<script)(\s[^>]*?>)',
+            'end': r'(</script>)',
+            'patterns': [
+              {'include': 'source.js'}
+            ]
+          },
+          {
+            'name': 'meta.embedded.style.html',
+            'begin': r'(<style)(\s[^>]*?>)',
+            'end': r'(</style>)',
+            'patterns': [
+              {'include': 'source.css'}
+            ]
+          }
+        ]
+      }
+    }
+  });
+}
+
+String _cssGrammarWithLocalInclude() {
+  return jsonEncode({
+    'name': 'CSS',
+    'scopeName': 'source.css',
+    'patterns': [
+      {'include': '#rules'}
+    ],
+    'repository': {
+      'rules': {
+        'patterns': [
+          {
+            'name': 'meta.rule-set.css',
+            'begin': r'([a-zA-Z0-9\-_*#.:\[\]\s]+)\s*(\{)',
+            'end': r'\}',
+            'patterns': [
+              {'include': '#properties'}
+            ],
+          }
+        ]
+      },
+      'properties': {
+        'patterns': [
+          {'name': 'support.type.property-name.css', 'match': r'\b[a-z-]+\b'},
+        ]
+      }
+    }
+  });
+}
+
+String _jsGrammarWithLocalInclude() {
+  return jsonEncode({
+    'name': 'JavaScript',
+    'scopeName': 'source.js',
+    'patterns': [
+      {'include': '#keywords'}
+    ],
+    'repository': {
+      'keywords': {
+        'patterns': [
+          {'name': 'keyword.control.js', 'match': r'\b(if|else|return)\b'}
+        ]
+      }
+    }
+  });
+}
+
+String? _findBeginPatternForMatcher(
+  Object? value,
+  String matcherName,
+) {
+  if (value is Map) {
+    final name = value['name'];
+    if (name == matcherName) {
+      final begin = value['begin'];
+      if (begin is String) {
+        return begin;
+      }
+    }
+
+    for (final entry in value.values) {
+      final result = _findBeginPatternForMatcher(entry, matcherName);
+      if (result != null) return result;
+    }
+  } else if (value is List) {
+    for (final entry in value) {
+      final result = _findBeginPatternForMatcher(entry, matcherName);
+      if (result != null) return result;
+    }
+  }
+
+  return null;
+}
+
+List<_TextLeaf> _flattenTextSpans(
+  TextSpan span, {
+  TextStyle inheritedStyle = const TextStyle(),
+}) {
+  final currentStyle = inheritedStyle.merge(span.style);
+  final leaves = <_TextLeaf>[];
+
+  final children = span.children;
+  if (children != null && children.isNotEmpty) {
+    for (final child in children) {
+      if (child is TextSpan) {
+        leaves.addAll(
+          _flattenTextSpans(
+            child,
+            inheritedStyle: currentStyle,
+          ),
+        );
+      }
+    }
+    return leaves;
+  }
+
+  final text = span.text;
+  if (text != null && text.isNotEmpty) {
+    leaves.add(_TextLeaf(text: text, style: currentStyle));
+  }
+  return leaves;
+}
+
+class _TextLeaf {
+  const _TextLeaf({
+    required this.text,
+    required this.style,
+  });
+
+  final String text;
+  final TextStyle style;
+}


### PR DESCRIPTION
## Summary
- replace `highlight`/`flutter_highlight` with `syntax_highlight` in the editor package
- add a TextMate highlighter registry with one-time grammar initialization and cached highlighters
- support canonical language aliases via `defaultLanguage` (`html|htm`, `css`, `javascript|js`)
- keep graceful plain-text fallback for unsupported languages, init failure, and runtime highlight errors
- preserve existing Atom One Dark-like editor colors

## Robustness
- pre-validate grammar regex keys (`match`, `begin`, `end`, `while`) with Dart `RegExp`
- replace invalid regex with a never-match sentinel and log warning summaries
- patch HTML embedding behavior for `<script>` / `<style>` and inline JS/CSS pattern expansion
- patch CSS rule-set selector matching to include comma/combinator selector forms so selectors color correctly

## Editor Integration
- refactor controller highlight flow to use cached TextMate highlighters
- wrap output in parent `TextSpan(style: style, ...)` to preserve inherited editor typography
- initialize highlighters asynchronously in `Editor.initState` with safe fallback behavior

## Tests
- language canonicalization and alias mapping
- unsupported language fallback/logging behavior
- regex sanitization replacement path
- grammar patch coverage for HTML/JS/CSS compatibility
- widget/controller regression tests for highlighting + editor responsiveness
- failure-path regression when initialization fails

## Validation
- `flutter test`
- `flutter analyze`
